### PR TITLE
MNT: Enable win64 build due to sgp4[win64] avaliability

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,13 +23,25 @@ environment:
       CONDA_PY: 27
       CONDA_INSTALL_LOCN: C:\\Miniconda
 
+    - TARGET_ARCH: x64
+      CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
+
     - TARGET_ARCH: x86
       CONDA_PY: 34
       CONDA_INSTALL_LOCN: C:\\Miniconda3
 
+    - TARGET_ARCH: x64
+      CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda3-x64
+
     - TARGET_ARCH: x86
       CONDA_PY: 35
       CONDA_INSTALL_LOCN: C:\\Miniconda35
+
+    - TARGET_ARCH: x64
+      CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
 
 # We always use a 64-bit machine, but can build x86 distributions

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,8 +17,8 @@ source:
     - py2compat.patch
 
 build:
-  skip: true  # [win64]
-  number: 0
+#  skip: true  # [win64]
+  number: 1
   script: python setup.py install
 
 requirements:


### PR DESCRIPTION
Re-rendered with conda-smithy 1.5.3