### PR TITLE
added dependency: jplephem

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,7 @@ build:
 requirements:
   build:
     - python
+    - jplephem
   run:
     - python
     - numpy


### PR DESCRIPTION
Regarding 'soft' dependency on jplephem package, preventing user from:

    import skyfield.api as sf

Discussion in https://github.com/conda-forge/skyfield-feedstock/issues/8